### PR TITLE
Changed the TPM NV state manufacturing logic used by the simulator. P…

### DIFF
--- a/TPMCmd/Platform/include/prototypes/Platform_fp.h
+++ b/TPMCmd/Platform/include/prototypes/Platform_fp.h
@@ -338,6 +338,13 @@ _plat__ClearNvAvail(
     void
     );
 
+//*** _plat__NVNeedsManufacture()
+// This function is used by the simulator to determine when the TPM's NV state
+// needs to be manufactured.
+LIB_EXPORT BOOL
+_plat__NVNeedsManufacture(
+    void
+    );
 
 //** From PowerPlat.c 
 


### PR DESCRIPTION
…reviously it (re-)manufactured its NV state every time its executable was started. Now it will only do automatic (re-)manufacturing if no NvChip file is found or if the file has wrong size.

Also added a command line option -m (--manufacture) to force NV state (re-)manufacturing.